### PR TITLE
fix: rename endpoint for production

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,4 @@
-export const endpoint = 'https://www.natorisana.love';
+export const endpoint = 'https://sanabutton.github.io';
 export const endpointV1 = `${endpoint}/api/v1`;
 export const endpointSound = `${endpoint}/sounds`;
-export const host = 'https://devel.natorisana.love';
+export const host = 'https://natorisana.love';


### PR DESCRIPTION
フロントエンドのアプリケーションから github.pages のサウンドデータを取得するようにする、 production 用変更です。

- [ ] natorisana.love がフロントエンドを向いていること